### PR TITLE
skip previously failed messages, allow to-field to be object

### DIFF
--- a/service/configuration/activities/org.webosports.service.messaging/org.webosports.service.messaging.assignMessages.json
+++ b/service/configuration/activities/org.webosports.service.messaging/org.webosports.service.messaging.assignMessages.json
@@ -23,7 +23,8 @@
 					"where": [
 						{ "op": ">", "prop": "_rev", "val": 0 },
 						{"prop": "conversations", "op": "=", "val": null},
-						{"prop": "flags.visible", "op": "=", "val": true}
+						{"prop": "flags.visible", "op": "=", "val": true},
+						{"prop": "flags.threadingError", "op": "=", "val": null}
 					]
 				}
 			}

--- a/service/configuration/db/kinds/com.palm.message
+++ b/service/configuration/db/kinds/com.palm.message
@@ -21,6 +21,7 @@
 			"props": [
 				{"default":null,"name":"conversations"},
 				{"default":true,"name":"flags.visible"},
+				{"default":null,"name":"flags.threadingError"},
 				{"name":"_rev"}
 			]
 		}, {

--- a/service/javascript/assistants/AssignMessages.js
+++ b/service/javascript/assistants/AssignMessages.js
@@ -264,7 +264,10 @@ AssignMessages.prototype.complete = function (activityObject) {
 				}));
 			} else {
 				Log.debug("Different activity, finish it");
-				future.nest(activityObject.complete());
+				activityObject.complete().then(function completeCB() {
+					Log.debug("Setting new rev in old activity.");
+					future.nest(PalmCall.call("palm://com.palm.activitymanager", "create", {activity: activity, start: true, replace: true}));
+				});
 			}
 			future.result = {returnValue: true};
 		}

--- a/service/javascript/assistants/AssignMessages.js
+++ b/service/javascript/assistants/AssignMessages.js
@@ -1,3 +1,4 @@
+/*jslint nomen: true*/
 /*global Future, console, DB, PalmCall, Contacts, checkResult, Log */
 
 var messageQuery = {
@@ -33,7 +34,7 @@ var activity = {
 	}
 };
 
-function setRev (newRev) {
+function setRev(newRev) {
 	"use strict";
 	activity.trigger.params.query.where[0].val = newRev;
 	activity.callback.params.lastCheckedRev = newRev;
@@ -46,6 +47,7 @@ var numProcessed = 0;
 var AssignMessages = function () { "use strict"; };
 
 AssignMessages.prototype.processMessage = function (msg) {
+	"use strict";
 	var future = new Future(), innerFuture;
 	Log.debug("Processing message ", msg);
 	if (msg.folder === "outbox") {
@@ -89,6 +91,7 @@ AssignMessages.prototype.processMessage = function (msg) {
 };
 
 AssignMessages.prototype.processMessageAndAddress = function (msg, address) {
+	"use strict";
 	var future = new Future(), name = "", normalizedAddress;
 	if (!msg.serviceName) {
 		console.warn("No service name in message, assuming sms.");
@@ -100,7 +103,7 @@ AssignMessages.prototype.processMessageAndAddress = function (msg, address) {
 	if (msg.serviceName === "sms" || msg.serviceName === "mms") {
 		future.nest(Contacts.Person.findByPhone(address, {
 			includeMatchingItem: false,
-			returnAllMatches: false,
+			returnAllMatches: false
 		}));
 		normalizedAddress = Contacts.PhoneNumber.normalizePhoneNumber(address);
 	} else {
@@ -238,6 +241,7 @@ AssignMessages.prototype.run = function (outerFuture) {
 };
 
 AssignMessages.prototype.complete = function (activityObject) {
+	"use strict";
 	Log.debug("Completing ", activityObject.name, " with id: ", activityObject._activityId);
 	var future = PalmCall.call("palm://com.palm.activitymanager", "getDetails", {"activityName": activity.name, current: false, internal: false});
 


### PR DESCRIPTION
additionally rewrites activity even during calls from command line (which updates _rev and other stuff in case something with activity was wrong before).