### PR TITLE
Fix empty PalmSystem.launchParams

### DIFF
--- a/app/source/views/views.js
+++ b/app/source/views/views.js
@@ -96,7 +96,13 @@ enyo.kind({
         try {
             this.log("sender:", inSender, ", event:", inEvent);
             this.log("launchParams: ", PalmSystem.launchParams);
-            var params = JSON.parse(PalmSystem.launchParams);
+			
+            var params;
+            try {
+                params = JSON.parse(PalmSystem.launchParams);
+            } catch (err) {
+                params = {}
+            }
             var threadParam, match;
 
             if (typeof(params.threadId) !== 'undefined') {


### PR DESCRIPTION
By not dealing with this properly we get:

Dec 13 11:52:18 qemux86 LunaWebAppManager[614]: WARNING: 11:52:18.691:
CONSOLE JS: messaging.MainView.handleRelaunch():  SyntaxError:
Unexpected end of input

Dec 13 11:52:18 qemux86 LunaWebAppManager[614]: WARNING: 11:52:18.691:
CONSOLE JS: Error
Dec 13 11:52:18 qemux86 LunaWebAppManager[614]:     at
Error (native)
Dec 13 11:52:18 qemux86 LunaWebAppManager[614]:     at e
(file:///usr/palm/applications/org.webosports.app.messaging/build/enyo.js:69:58)
Dec
13 11:52:18 qemux86 LunaWebAppManager[614]:     at Object.i.error
(file:///usr/palm/applications/org.webosports.app.messaging/build/enyo.js:69:1325)
Dec
13 11:52:18 qemux86 LunaWebAppManager[614]:     at
Object.enyo.kind.handleRelaunch
(file:///usr/palm/applications/org.webosports.app.messaging/build/app.js:335:2741)
Dec
13 11:52:18 qemux86 LunaWebAppManager[614]:     at Object.<anonymous>
(file:///usr/palm/applications/org.webosports.app.messaging/build/app.js:335:3385)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>