### PR TITLE
package.json: Add missing icon.png

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,8 @@
   "assets": [
     "appinfo.json",
     "favicon.ico",
-    "assets/**/*"
+    "icon.png",
+    "assets/**/*"     
   ],
   "devAssets": [
     "mock/**/*"


### PR DESCRIPTION
App Icon disappeared in build, turned out that icon.png was missing from assets in package.json

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>